### PR TITLE
Fix HSL to RGB conversion when hue < 60

### DIFF
--- a/lib/chameleon/hsl.ex
+++ b/lib/chameleon/hsl.ex
@@ -39,9 +39,7 @@ defmodule Chameleon.HSL do
 
   defp remainder(h) do
     a = h / 60.0
-    dec = a - Float.floor(a)
-    mod = rem(round(a), 2)
-    mod + dec
+    :math.fmod(a, 2)
   end
 
   defp calculate_rgb(c, x, h) when h < 60, do: [c, x, 0]


### PR DESCRIPTION
# Problem
When converting from HSL to RGB, the RGB values do not always come out as expected. This is only an issue when the original color's hue value is less than 60, which, when divided by `60.0` in the `remainder` function, results in a value less than 1 but greater than or equal to 0.

In the example below, converting the color to RGB changes it from yellow to red:

```elixir
iex> color = Chameleon.HSL.new(59, 91, 57)
%Chameleon.HSL{h: 59, l: 57, s: 91}

iex> Chameleon.convert(color, Chameleon.RGB)
%Chameleon.RGB{b: 46, g: 49, r: 245}

# Expected Output: %Chameleon.RGB{b: 48, g: 242, r: 245}
```

![Example1](https://user-images.githubusercontent.com/8515722/143310067-7982b7e2-5a32-4c15-a29d-19ac45d05488.png)

The following example uses the same color, but the hue has been shifted to `60`, making the value of `h / 60.0` a whole number and resulting in the correct conversion:

```elixir
iex> color = Chameleon.HSL.new(60, 91, 57)
%Chameleon.HSL{h: 60, l: 57, s: 91}

iex> Chameleon.convert(color, Chameleon.RGB)
%Chameleon.RGB{b: 46, g: 245, r: 245}

# Expected Output: %Chameleon.RGB{b: 48, g: 245, r: 245}
```

![Example2](https://user-images.githubusercontent.com/8515722/143310077-3f571558-d4fd-4560-97c0-200725c5f05b.png)


# Solution
Leverage Erlang's `:math.fmod` function in the `remainder` function to properly handle cases where dividing the hue by `60.0` results in a non-whole number.

Using the examples above, we can see the comparison of running the remainder function before and after this change:

```elixir
# Example 1 - Before
iex> remainder(59)
1.9833333333333334

# Example 1 - After
iex> remainder(59)
0.9833333333333333

# Example 2 - Before
iex> remainder(60)
1.0

# Example 2 - After
iex> remainder(60)
1.0
```